### PR TITLE
Shorten 3PAR object names

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ directory and have to be installed to `/var/lib/one/remotes/vmm/kvm/`.
 
 ### Configuring the System Datastore
 
-This addon enables full support of transfer manager (TM_MAD) backend of type 3par for the system datastore.  
+This addon enables full support of transfer manager (TM_MAD) backend of type 3par for the system datastore.
 The system datastore will hold only the symbolic links to the 3PAR block devices and context isos, so it will not take much space. See more details on the [Open Cloud Storage Setup](https://docs.opennebula.org/5.8/deployment/open_cloud_storage_setup/).
 
 ### Configuring the Datastore
@@ -239,8 +239,8 @@ Some configuration attributes must be set to enable a datastore as 3PAR enabled 
 
 1. Volume names are created according to best practices naming conventions.
    `<TYPE>` part - can be prd for production servers, dev for development servers, tst for test servers, etc.
-   Volume name will be `<TYPE>.one.<IMAGE_ID>.vv` for ex. `dev.one.1.vv` or `tst.one.3.vv`
-   
+   Volume name will be `<TYPE>.<IMAGE_ID>` for ex. `dev.1` or `tst.3`
+
 2. Quoted, space separated list of server hostnames which are Hosts on the 3PAR System.
 
 3. QoS Rules - Applied per VM, so if VM have multiple disks, them QoS policy applies to all VM disks

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,8 @@
+# Upgrade from 2.0.4 to 3.0.0
+
+Replace all 3PAR driver files in your cluster with the ones in `interop` branch.  
+Before running any renaming scripts, read their `--help`, then do a dry run for each and verify it's output.  
+First run 3PAR renaming script `scripts/3parRename.py <IP> <USER> <PASSWORD_FILE>`.  
+Then run `scripts/ONRename.sh -n <NAMING_TYPE>` on your ON controller node (has to have onedb access).  
+Order matters!  
+Finally replace the 3PAR driver with the 3.0.0 version.  

--- a/datastore/3par/3par.py
+++ b/datastore/3par/3par.py
@@ -335,7 +335,7 @@ def monitorCPG(cl, args):
         diskResult = []
         for disk in disks:
           if disk.get('CLONE') == 'YES' or disk.get('SOURCE') is None or disk.get('SOURCE') == '':
-            name = '{namingType}.one.vm.{vmId}.{diskId}.vv'.format(namingType=args.namingType, vmId=vm.get('ID'), diskId=disk.get('DISK_ID'))
+            name = '{namingType}.vm.{vmId}.{diskId}'.format(namingType=args.namingType, vmId=vm.get('ID'), diskId=disk.get('DISK_ID'))
           else:
             source = disk.get('SOURCE').split(':')
             name = source[0]
@@ -517,7 +517,7 @@ def mvVmClone(cl, args):
 
 def createVVSetSnapshot(cl, args):
     snapId = 's{snapId}'.format(snapId=args.snapId)
-    vvsetName = '{namingType}.one.vm.{vmId}.vvset'.format(namingType=args.namingType, vmId=args.vmId)
+    vvsetName = '{namingType}.vm.{vmId}'.format(namingType=args.namingType, vmId=args.vmId)
 
     # get volume set info
     try:
@@ -559,7 +559,7 @@ def createVVSetSnapshot(cl, args):
 
 def deleteVVSetSnapshot(cl, args):
     snapId = 's{snapId}'.format(snapId=args.snapId)
-    vvsetName = '{namingType}.one.vm.{vmId}.vvset'.format(namingType=args.namingType, vmId=args.vmId)
+    vvsetName = '{namingType}.vm.{vmId}'.format(namingType=args.namingType, vmId=args.vmId)
 
     # get volume set info
     try:
@@ -769,7 +769,7 @@ def getIscsiPortals(cl, args):
     return
 
 def addVolumeToVVSet(cl, args):
-    vvsetName = '{namingType}.one.vm.{vmId}.vvset'.format(namingType=args.namingType, vmId=args.vmId)
+    vvsetName = '{namingType}.vm.{vmId}'.format(namingType=args.namingType, vmId=args.vmId)
 
     # get or create vvset
     try:
@@ -786,7 +786,7 @@ def addVolumeToVVSet(cl, args):
 
 
 def deleteVolumeFromVVSet(cl, args):
-    vvsetName = '{namingType}.one.vm.{vmId}.vvset'.format(namingType=args.namingType, vmId=args.vmId)
+    vvsetName = '{namingType}.vm.{vmId}'.format(namingType=args.namingType, vmId=args.vmId)
 
     # remove volume from volume set
     try:
@@ -814,7 +814,7 @@ def deleteVolumeFromVVSet(cl, args):
 
 
 def createQosPolicy(cl, args):
-    vvsetName = '{namingType}.one.vm.{vmId}.vvset'.format(namingType=args.namingType, vmId=args.vmId)
+    vvsetName = '{namingType}.vm.{vmId}'.format(namingType=args.namingType, vmId=args.vmId)
 
     # create QoS policy if not exists
     qosRules = prepareQosRules(args)
@@ -835,7 +835,7 @@ def createQosPolicy(cl, args):
 
 
 def deleteQosPolicy(cl, args):
-    vvsetName = '{namingType}.one.vm.{vmId}.vvset'.format(namingType=args.namingType, vmId=args.vmId)
+    vvsetName = '{namingType}.vm.{vmId}'.format(namingType=args.namingType, vmId=args.vmId)
 
     # get volume set info
     try:
@@ -863,10 +863,10 @@ def createPortName(portPos):
     return '{node}:{slot}:{cardPort}'.format(node=portPos['node'], slot=portPos['slot'], cardPort=portPos['cardPort'])
 
 def createVVName(namingType, id):
-    return '{namingType}.one.{id}.vv'.format(namingType=namingType, id=id)
+    return '{namingType}.{id}'.format(namingType=namingType, id=id)
 
 def createVmCloneName(namingType, id, vmId):
-    return '{namingType}.one.vm.{vmId}.{id}.vv'.format(namingType=namingType, id=id, vmId=vmId)
+    return '{namingType}.vm.{vmId}.{id}'.format(namingType=namingType, id=id, vmId=vmId)
 
 def createSnapshotNameAndMetaKey(srcName, snapId):
     name = '{srcName}.{snapId}'.format(srcName=srcName, snapId=snapId)

--- a/etc/datastore/3par/3par.conf
+++ b/etc/datastore/3par/3par.conf
@@ -50,8 +50,8 @@ COMPRESSION=NO
 
 # Volume names are created according to best practices naming conventions
 # <TYPE> part - can be prd for production servers, dev for development servers, tst for test servers, etc.
-# Volume name will be <TYPE>.one.<IMAGE_ID>.vv
-# Ex. dev.one.1.vv or tst.one.3.vv
+# Volume name will be <TYPE>.<IMAGE_ID>
+# Ex. dev.1 or tst.3
 NAMING_TYPE=dev
 
 # -------------------------------------------------------------------------------------- #

--- a/scripts/3parRename.py
+++ b/scripts/3parRename.py
@@ -1,0 +1,188 @@
+#!/usr/bin/python3
+
+from hpe3parclient import client,exceptions
+import sys
+from argparse import ArgumentParser
+
+parser = ArgumentParser()
+
+parser.add_argument("-r", "--reverse",action='store_true',help='Rename all 3PAR devices back to the old naming scheme')
+parser.add_argument("-d", "--dry-run",action='store_true',dest="dryrun",help="Do not rename, only show how names would be changed")
+parser.add_argument("-i", "--insecure",action='store_false',dest="secure",help="Allow insecure SSL")
+parser.add_argument("-p", "--port",action='store',default=8080,help="WSAPI Server Port number")
+parser.add_argument("-P", "--proto",default="https",help="WSAPI Server protocol [HTTP/HTTPS]")
+parsed, args = parser.parse_known_args()
+#print(args)
+
+port = parsed.port
+proto = parsed.proto.lower()
+ip = args[0]
+username = args[1]
+pw_file = args[2]
+
+api = proto + "://" + args[0] + ":" + str(port) + "/api/v1"
+f = open(args[2],"r")
+pw = f.readline().splitlines()[0]
+#print(args," ",api," ",args[1])
+print(api," ",args[1])
+
+cl = client.HPE3ParClient(api, False, parsed.secure, None, True)
+cl.setSSHOptions(args[0], args[1], pw)
+try:
+    cl.login(args[1], pw)
+except exceptions.HTTPUnauthorized as ex:
+    print("Login failed.")
+    print(ex)
+    exit(1)
+
+try:
+    print(cl.getStorageSystemInfo().get('name'))
+    if parsed.dryrun:
+        print("Dry run")
+    else:
+        print("Live run")
+    if parsed.secure:
+        print("Secure")
+    else:
+        print("Insecure")
+except Exception as ex:
+    print(ex)
+    exit;
+
+i = input("Everything in order? [y/n]")
+if  i != "y":
+    cl.logout()
+    exit()
+
+try:
+    vvs = cl.getVolumes()
+    vvsets = cl.getVolumeSets()
+except Exception as ex:
+    print(ex)
+    exit(1)
+
+pr=False
+rejects = []
+rejectsSet = []
+def rename():
+    global pr
+    for vv in vvs.get('members'):
+        name=vv.get('name')
+        splitName = name.split('.')
+        if len(splitName) < 3:
+            rejects.append(vv.get('name'))
+            continue
+        if splitName[1] == "one":
+            del splitName[1]
+        else:
+            rejects.append(vv.get('name'))
+            continue;
+        pr=True
+        if splitName[len(splitName)-2] == "checkpoint":
+            splitName[len(splitName)-2]="cp"
+        if splitName[len(splitName)-1] == "vv":
+            del splitName[len(splitName)-1]
+        if splitName[len(splitName)-1].startswith("vv-"):
+            afterDash = splitName[len(splitName)-1].split('-')[1]
+            splitName[len(splitName)-2] += "-" + afterDash
+            del splitName[len(splitName)-1]
+        nameChanged = ".".join(splitName)
+        print(name + "->" + nameChanged)
+        if parsed.dryrun:
+            continue
+        try:
+            cl.modifyVolume(name, {'newName':nameChanged})
+        # except exceptions.HTTPBadRequest:
+        # except exceptions.HTTPForbidden:
+        # except exceptions.HTTPInternalServerError:
+        # except exceptions.HTTPConflict:
+        except Exception as ex:
+            print(ex)
+
+    for vvset in vvsets.get('members'):
+        name=vvset.get('name')
+        splitName = name.split('.')
+        if len(splitName) < 3:
+            rejects.append(vvset.get('name'))
+            continue
+        if splitName[1] == "one":
+            del splitName[1]
+        else:
+            rejects.append(vvset.get('name'))
+            continue;
+        pr=True
+        if splitName[len(splitName)-1] == "vvset":
+            del splitName[len(splitName)-1]
+        nameChanged = ".".join(splitName)
+        print(name + "->" + nameChanged)
+        if parsed.dryrun:
+            continue
+        try:
+            cl.modifyVolumeSet(name, newName=nameChanged )
+        except Exception as ex:
+            print(ex)
+
+def renameReverse():
+    global pr
+    for vv in vvs.get('members'):
+        name=vv.get('name')
+        splitName = name.split('.')
+        if len(splitName) < 2 or splitName[len(splitName)-1].startswith('vv'):
+            rejects.append(vv.get('name'))
+            continue
+        if '' in splitName:
+            rejects.append(vv.get('name'))
+            continue
+        pr=True
+        splitName.insert(1,"one")
+        if splitName[len(splitName)-1] == "cp":
+            splitName[len(splitName)-1]="checkpoint"
+        if '-' in splitName[len(splitName)-1]:
+            last = splitName[len(splitName)-1].split('-')
+            splitName[len(splitName)-1]=last[0]
+            splitName.append("vv-" + last[1])
+        else:
+            splitName.append("vv")
+        nameChanged = ".".join(splitName)
+        print(name + "->" + nameChanged)
+        if parsed.dryrun:
+            continue
+        try:
+            cl.modifyVolume(name, {'newName':nameChanged})
+        except Exception as ex:
+            print(ex)
+
+    for vvset in vvsets.get('members'):
+        name=vvset.get('name')
+        splitName = name.split('.')
+        if len(splitName) < 2 or splitName[len(splitName)-1].startswith('vv'):
+            rejects.append(vvset.get('name'))
+            continue
+        if '' in splitName:
+            rejects.append(vvset.get('name'))
+            continue
+        pr=True
+        splitName.insert(1,"one")
+        splitName.insert(len(splitName),"vvset")
+        nameChanged = ".".join(splitName)
+        print(name + "->" + nameChanged)
+        if parsed.dryrun:
+            continue
+        try:
+            cl.modifyVolumeSet(name, newName=nameChanged )
+        except Exception as ex:
+            print(ex)
+
+if parsed.reverse:
+    print("reverse")
+    renameReverse()
+else:
+    print("normal")
+    rename()
+
+if pr:
+    print("\n\nRejects")
+    print(rejects)
+    print(rejectsSet)
+
+cl.logout()

--- a/scripts/ONRename.sh
+++ b/scripts/ONRename.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+
+trap 'exit' INT TERM
+trap 'kill 0' EXIT
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    -h|--help)
+        echo "ON database renaming script for 3PAR VVs"
+        echo "Options:"
+        echo "    -n, --naming    3PAR naming type, e.g.: 'dev'"
+        echo "    -r, --reverse   Rename from new scheme to the old one"
+        echo "    -D, --database  ON database name"
+        echo "    -d, --dry-run   Do not rename, only show differences"
+        echo "    -o, --output    Directory for dry-run diff files. Defaults to '/var/tmp'"
+        exit
+        ;;
+    -r|--reverse)
+        REVERSE=1
+        shift
+        ;;
+    -n|--naming)
+        namingType=$2
+        shift
+        shift
+        ;;
+    -D|--database)
+        DB=$2
+        shift
+        shift
+        ;;
+    -d|--dry-run)
+        dryRun=1
+        shift
+        ;;
+    -o|--output)
+        outDir=$2
+        shift
+        shift
+        ;;
+    *)
+        echo "Unknown argument $1 - skipping"
+        shift
+        ;;
+    esac
+done
+
+if [[ -z $namingType ]]; then
+    echo "Missing naming type"
+    exit 1
+fi;
+outDir=${outDir:-"/var/tmp"}
+
+if (( dryRun )); then
+    echo "Dry run!"
+    echo "Output directory: '$outDir'"
+else
+    echo "Live run!"
+fi;
+if (( REVERSE )); then
+    echo "Reverse"
+else
+    echo "Normal"
+fi;
+echo "$namingType"
+echo "Is everything correct? [y/n]"
+read IN
+if [[ $IN != "y" ]]; then
+    exit 0
+fi;
+
+DB=${DB:-"opennebula"}
+# DB access? rewriting VMs?
+#DB_VMs=$(mysql $DB <<< "select oid from vm_pool order by oid desc;")
+VMs=$(onevm list --no-pager --no-header | mawk '{print $1}')
+lastVM=$(echo "$VMs" | sort -nr | head -n1)
+images=$(oneimage list --no-pager --no-header | mawk '{print $1}')
+declare -ag imageArray
+imageArray=($images)
+
+if (( REVERSE )); then
+    #'/stg2\..*[0-9]:/ {s/stg2/stg2.one/; s/:/.vv:/}
+    CMD="/usr/bin/sed -i '/$namingType\..*[0-9]:/ {s/$namingType/$namingType.one/; s/:/.vv:/}'"
+else
+    #'/stg2\.one\..*\.vv:/ {s/\.one//; s/\.vv:/:/}'
+    CMD="/usr/bin/sed -i '/$namingType\.one\..*\.vv:/ {s/\.one//; s/\.vv:/:/}'"
+fi;
+
+#echo -e "VM IDs:\n$VMs"
+#echo -e "Image IDs:\n$images"
+#echo "--------"
+#echo $CMD
+#exit
+function updateVM(){
+    echo "Job: $1 -- $2 "
+    for VM in $(seq $1 $2); do
+        echo "$VM"
+        #read _
+        out=$(onedb show-body vm --id $VM 2>/dev/null) || continue
+        if [[ $out == "undefined method \`first' for nil:NilClass" ]]; then continue; fi;
+        EDITOR="$CMD" onedb update-body vm --id $VM
+    done;
+}
+
+function updateImage(){
+    echo "Job: $@"
+    for image in $@; do
+        echo "$image"
+        out=$(onedb show-body image --id $image 2>/dev/null) || continue
+        if [[ $out == "undefined method \`first' for nil:NilClass" ]]; then continue; fi;
+        #read _
+        EDITOR="$CMD" onedb update-body image --id $image
+    done;
+}
+
+if (( dryRun )); then
+    if (( REVERSE )); then
+        #'/stg2\..*[0-9]:/ {s/stg2/stg2.one/; s/:/.vv:/}
+        CMD="/usr/bin/sed \"/<SOURCE><\!\[CDATA\[$namingType\..*[0-9]:/ {s/$namingType/$namingType.one/; s/:/.vv:/}\""
+    else
+        #'/stg2\.one\..*\.vv:/ {s/\.one//; s/\.vv:/:/}'
+        CMD="/usr/bin/sed \"/<SOURCE><\!\[CDATA\[$namingType\.one\..*\.vv:/ {s/\.one//; s/\.vv:/:/}\""
+    fi;
+    if [[ -d "$outDir/db.bak" ]]; then
+        rm -rf "$outDir/db.bak/"
+    fi
+    mkdir $outDir/db.bak
+    function updateVM(){
+        echo "Job: $1 -- $2 "
+        for VM in $(seq $1 $2); do
+            #echo "$VM"
+            #echo "$CMD"
+            #sleep 1
+            #read _
+            out=$(onedb show-body vm --id $VM 2>/dev/null) || continue
+            if [[ $out == "undefined method \`first' for nil:NilClass" ]]; then continue; fi;
+            echo "$out" > $outDir/db.bak/$VM.vm
+            #set -x
+            DIFF=$(eval "$CMD $outDir/db.bak/$VM.vm" | diff $outDir/db.bak/$VM.vm -)
+            echo -e "$VM $DIFF"
+            #set +x
+        done;
+    }
+    function updateImage(){
+        echo "Job: $@"
+        for image in $@; do
+            #echo "$image"
+            #read _
+            out=$(onedb show-body image --id $image 2>/dev/null) || continue
+            if [[ $out == "undefined method \`first' for nil:NilClass" ]]; then continue; fi;
+            echo "$out" > $outDir/db.bak/$image.image
+            DIFF=$(eval "$CMD $outDir/db.bak/$image.image" | diff $outDir/db.bak/$image.image -)
+            echo -e "$image $DIFF"
+        done;
+    }
+fi;
+
+
+JOBS=4
+job_range=$((lastVM/JOBS))
+start=0
+for i in $(seq 1 $JOBS); do
+    end=$((start+job_range-1))
+    if (( i == $JOBS)); then end=$lastVM; fi;
+    updateVM $start $end &
+  #  for VM in $(seq $start $end); do
+  #      echo "$VM"
+  #      #read _
+  #      #EDITOR="$CMD" onedb update-body vm --id $VM
+  #  done;
+    start=$((start+job_range))
+done;
+wait
+echo "---------- VMs Done ----------"
+echo $images
+imageLen=${#imageArray[@]}
+job_range=$((imageLen/JOBS))
+start=0
+for i in $(seq 1 $JOBS); do
+    end=$((start+job_range-1))
+    if (( i == $JOBS)); then job_range=$imageLen; fi;
+    #echo "${imageArray[@]:$start:$job_range}"
+    updateImage "${imageArray[@]:$start:$job_range}" &
+    start=$((start+job_range))
+done;
+wait;
+trap - EXIT

--- a/tm/3par/mv
+++ b/tm/3par/mv
@@ -262,8 +262,8 @@ if [ `is_disk $DST_PATH` -eq 0 ]; then
 
     # get VM checkpoint WWN, if any
     SRC_NAME_WWN=$(${DRIVER_PATH}/../../datastore/3par/3par.py getVmClone -a $SRC_API_ENDPOINT -i $SRC_IP -s $SECURE -u $USERNAME \
-                                                                  -p $PASSWORD -nt $SRC_NAMING_TYPE -vi $VMID -id checkpoint)
-    
+                                                                  -p $PASSWORD -nt $SRC_NAMING_TYPE -vi $VMID -id cp)
+
     if [ $? -ne 0 ]; then
         # for SUSPENDED it must exist otherwise exit with no error
         if [[ "$LCM_STATE" =~ ^(45|46)$ ]]; then
@@ -313,8 +313,8 @@ if [ `is_disk $DST_PATH` -eq 0 ]; then
 
             DST_NAME_WWN=$(${DRIVER_PATH}/../../datastore/3par/3par.py createVmVV -a $DST_API_ENDPOINT -i $DST_IP -s $SECURE -u $USERNAME \
                                             -p $PASSWORD -nt $DST_NAMING_TYPE -tpvv $DST_THIN -tdvv $DST_DEDUP -compr $DST_COMPRESSION \
-                                            -vi $VMID -id checkpoint -c $DST_CPG -sz $SIZE -co "$VM_NAME")
-    
+                                            -vi $VMID -id cp -c $DST_CPG -sz $SIZE -co "$VM_NAME")
+
             if [ $? -ne 0 ]; then
               error_message "$DST_NAME_WWN"
               exit 1
@@ -460,7 +460,7 @@ EOF
         fi
     
         VV=$(${DRIVER_PATH}/../../datastore/3par/3par.py deleteVmClone -a $SRC_API_ENDPOINT -i $SRC_IP -s $SECURE -u $USERNAME -p $PASSWORD \
-                            -nt $SRC_NAMING_TYPE -vi $VMID -id checkpoint)
+                            -nt $SRC_NAMING_TYPE -vi $VMID -id cp)
         if [ $? -ne 0 ]; then
             error_message "$VV"
             exit 1

--- a/vmm/kvm/restore-3par
+++ b/vmm/kvm/restore-3par
@@ -98,7 +98,7 @@ fi
 
 # get VM disk WWN
 NAME_WWN=$(${DRIVER_PATH}/../../datastore/3par/3par.py getVmClone -a $API_ENDPOINT -i $IP -s $SECURE -u $USERNAME \
-                                                            -p $PASSWORD -nt $NAMING_TYPE -vi $VMID -id checkpoint)
+                                                            -p $PASSWORD -nt $NAMING_TYPE -vi $VMID -id cp)
 
 if [ $? -ne 0 ]; then
   error_message "$NAME_WWN"
@@ -202,4 +202,4 @@ if [ $? -ne 0 ]; then
 fi
 
 ${DRIVER_PATH}/../../datastore/3par/3par.py deleteVmClone -a $API_ENDPOINT -i $IP -s $SECURE -u $USERNAME -p $PASSWORD \
-                                                            -nt $NAMING_TYPE -vi $VMID -id checkpoint
+                                                            -nt $NAMING_TYPE -vi $VMID -id cp

--- a/vmm/kvm/save-3par
+++ b/vmm/kvm/save-3par
@@ -138,7 +138,7 @@ SIZE=$((SIZE_K/1024))
 
 NEW_NAME_WWN=$(${DRIVER_PATH}/../../datastore/3par/3par.py createVmVV -a $API_ENDPOINT -i $IP -s $SECURE -u $USERNAME \
                                 -p $PASSWORD -nt $NAMING_TYPE -tpvv $THIN -tdvv $DEDUP -compr $COMPRESSION \
-                                -vi $VMID -id checkpoint -c $CPG -sz $SIZE -co "$VM_NAME")
+                                -vi $VMID -id cp -c $CPG -sz $SIZE -co "$VM_NAME")
 
 if [ $? -ne 0 ]; then
   error_message "$NEW_NAME_WWN"


### PR DESCRIPTION
Hi, I've made a patch to shorten 3PAR object names. It is a small, but breaking change. 

The reason for it is, that 3PAR has very limited name lengths (31 characters for VVs, 27 for VVsets) and the names as they are now easily cause trouble with some 3PAR functionality. 
For example 3PAR Remote Copy Groups are limited to only 22 characters and when you have a VV like 'dev.one.vm.10700.0.vv', that's already 1 character over limit and it's not the longest name I've seen. Another example of long names could be snapshots. 

To avoid this problem I shortened the names like this:
VM Disks:  `{namingType}.vm.{vmId}.{diskId}`
VM Checkpoints:  `{namingType}.vm.{vmId}.cp`
Base images: `{namingType}.{imageId}`
VV Sets: `{namingType}.vm.{vmId}`