### PR TITLE
Fix resizing of persistent drives

### DIFF
--- a/tm/3par/resize
+++ b/tm/3par/resize
@@ -75,28 +75,27 @@ SYS_DSID="${XPATH_ELEMENTS[j++]}"
 [ "$READONLY" == "YES" ] && exit 1
 
 #-------------------------------------------------------------------------------
+# Get system ds information
+#-------------------------------------------------------------------------------
+  
+unset i j XPATH_ELEMENTS
+  
+while IFS= read -r -d '' element; do
+    XPATH_ELEMENTS[i++]="$element"
+done < <(onedatastore show -x $SYS_DSID | $XPATH \
+                   /DATASTORE/TEMPLATE/API_ENDPOINT \
+                   /DATASTORE/TEMPLATE/IP \
+                   /DATASTORE/TEMPLATE/NAMING_TYPE)
+
+API_ENDPOINT="${XPATH_ELEMENTS[j++]:-$API_ENDPOINT}"
+IP="${XPATH_ELEMENTS[j++]:-$IP}"
+NAMING_TYPE="${XPATH_ELEMENTS[j++]:-$NAMING_TYPE}"
+  
+#-------------------------------------------------------------------------------
 # Start actions
 #-------------------------------------------------------------------------------
 
 if [ "$PERSISTENT" != "YES" ]; then
-  #-------------------------------------------------------------------------------
-  # Get system ds information
-  #-------------------------------------------------------------------------------
-  
-  unset i j XPATH_ELEMENTS
-  
-  while IFS= read -r -d '' element; do
-      XPATH_ELEMENTS[i++]="$element"
-  done < <(onedatastore show -x $SYS_DSID | $XPATH \
-                     /DATASTORE/TEMPLATE/API_ENDPOINT \
-                     /DATASTORE/TEMPLATE/IP \
-                     /DATASTORE/TEMPLATE/NAMING_TYPE)
-
-  API_ENDPOINT="${XPATH_ELEMENTS[j++]:-$API_ENDPOINT}"
-  IP="${XPATH_ELEMENTS[j++]:-$IP}"
-  NAMING_TYPE="${XPATH_ELEMENTS[j++]:-$NAMING_TYPE}"
-
-
 
   # get VM disk WWN
   NAME_WWN=$(${DRIVER_PATH}/../../datastore/3par/3par.py getVmClone -a $API_ENDPOINT -i $IP -s $SECURE -u $USERNAME \


### PR DESCRIPTION
Persistent disks can't be resized because 3par.py does not receive API_SERVER variable